### PR TITLE
EID-428: Allow changing EncrypterFactory options

### DIFF
--- a/src/main/java/uk/gov/ida/saml/security/EncrypterFactory.java
+++ b/src/main/java/uk/gov/ida/saml/security/EncrypterFactory.java
@@ -7,11 +7,22 @@ import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import org.opensaml.xmlsec.encryption.support.KeyEncryptionParameters;
 
 public class EncrypterFactory {
-
+    private String keyEncryptionAlgorithm = EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP;
     private String dataEncryptionAlgorithm = EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128;
+    private Encrypter.KeyPlacement keyPlacement = Encrypter.KeyPlacement.PEER;
 
-    public EncrypterFactory withAes256Encryption() {
-        dataEncryptionAlgorithm = EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256;
+    public EncrypterFactory withKeyEncryptionAlgorithm(String algorithm) {
+        keyEncryptionAlgorithm = algorithm;
+        return this;
+    }
+
+    public EncrypterFactory withDataEncryptionAlgorithm(String algorithm) {
+        dataEncryptionAlgorithm = algorithm;
+        return this;
+    }
+
+    public EncrypterFactory withKeyPlacement(Encrypter.KeyPlacement keyPlacement) {
+        this.keyPlacement = keyPlacement;
         return this;
     }
 
@@ -21,10 +32,10 @@ public class EncrypterFactory {
 
         KeyEncryptionParameters kekParams = new KeyEncryptionParameters();
         kekParams.setEncryptionCredential(credential);
-        kekParams.setAlgorithm(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP);
+        kekParams.setAlgorithm(keyEncryptionAlgorithm);
 
         Encrypter encrypter = new Encrypter(encParams, kekParams);
-        encrypter.setKeyPlacement(Encrypter.KeyPlacement.PEER);
+        encrypter.setKeyPlacement(keyPlacement);
 
         return encrypter;
     }


### PR DESCRIPTION
To use EncrypterFactory for non-Verify purposes such as eIDAS, we need
to be able to change the encryption algorithms and key placement used. The
`withAes256Encryption()` method was only used in one place (Stub IDP)
for eIDAS reasons so it should be changed there to use the more general
method.

Author: @vixus0