### PR TITLE
TT-2116: Remove log4j as logback and slf4j are used for logging. Add …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
 
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'maven'
+
 
 ext {
     opensaml_version = '3.3.0'
@@ -36,8 +38,7 @@ dependencies {
             configurations.opensaml,
             'com.google.guava:guava:18.0',
             'joda-time:joda-time:2.9',
-            'org.apache.santuario:xmlsec:1.5.7',
-            'log4j:log4j:1.2.14'
+            'org.apache.santuario:xmlsec:1.5.7'
 
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'saml-security'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'saml-security'


### PR DESCRIPTION
…settings.gradle file which sets project name to saml-security thereby making the name consistent with the published name.

Co-authored-by: Robin Mitra <robin.mitra@digital.cabinet-office.gov.uk>
Co-authored-by: Richard Towers <richard.towers@digital.cabinet-office.gov.uk>